### PR TITLE
setRawHeader

### DIFF
--- a/src/Request.php
+++ b/src/Request.php
@@ -159,6 +159,24 @@ class Request
 
 		return $this;
 	}
+	
+	/**
+	 * Set a specific header to be sent with the request.
+	 *
+	 * @param string $key   Can also be a string in "foo: bar" format
+	 * @param mixed  $value
+	 */
+	public function setRawHeader($key, $value = null)
+	{
+		if ($value === null) {
+			list($key, $value) = explode(':', $value, 2);
+		}
+
+		$key = trim($key);
+		$this->headers[$key] = trim($value);
+
+		return $this;
+	}
 
 	/**
 	 * Set the headers to be sent with the request.


### PR DESCRIPTION
There are some libraries or API  (e.g. http://developer.onepagecrm.com/#signing-process)
where you need to use case sensitive in the headers. I added a new setRawHeader removing the tolowercase function
